### PR TITLE
Add short-circuiting version of thrush, thrush-and

### DIFF
--- a/point-free/point-free.scrbl
+++ b/point-free/point-free.scrbl
@@ -3,6 +3,7 @@
 @(require scribble/eval
           (for-label point-free
                      racket/base
+                     racket/contract
                      racket/function
                      racket/list))
 
@@ -75,6 +76,24 @@ of function composition.
     ((thrush* "foo" "bar") string-append string-length)
     ]}
 
+@deftogether[(@defproc[(thrush-and [f procedure?] ...) procedure?]
+              @defproc[(λand~> [f procedure?] ...) procedure?])]{
+  Like @racket[thrush], performs reverse function composition. However, @racket[thrush-and] includes
+  the short-circuiting behavior of @racket[and], so if any intermediate function returns @racket[#f],
+  the entire chain returns @racket[#f] without continuing to thread the value through the chain.
+  @examples[#:eval the-eval
+    (define find-odd (curry findf odd?))
+    ((thrush-and find-odd add1) '(2 3 4))
+    ((thrush-and find-odd add1) '(2 4 6))
+    ]}
+
+@deftogether[(@defproc[(thrush+-and [v any/c] [f procedure?] ...) any]
+              @defproc[(and~> [v any/c] [f procedure?] ...) any]
+              @defproc[((thrush*-and [v any/c] ...) [f procedure?] ...) any]
+              @defproc[((and~>* [v any/c] ...) [f procedure?] ...) any])]{
+  Like @racket[thrush+] and @racket[thrush*], but with the short-circuiting behavior of
+  @racket[thrush-and].}
+
 @section{Define forms of function composition}
 
 @defform[(define/compose name func-expr ...)]{
@@ -91,6 +110,14 @@ of function composition.
     (define/thrush symbol-length symbol->string string-length)
     (symbol-length 'foo)
     (symbol-length 'bazzz)
+    ]}
+
+@defform[(define/thrush-and name func-expr ...)]{
+  Defines @racket[name] as the result of @racket[(thrush-and func-expr ...)].
+  @examples[#:eval the-eval
+    (define/thrush-and inc-odd (curry findf odd?) add1)
+    (inc-odd '(2 3 4))
+    (inc-odd '(2 4 6))
     ]}
 
 @section{Point-free argument counts}

--- a/point-free/thrush.rkt
+++ b/point-free/thrush.rkt
@@ -1,15 +1,21 @@
 #lang racket
 
-
 (require rackunit)
 
 (provide thrush
          thrush+
          thrush*
          define/thrush
-         ~>
-         λ~>
-         ~>*)
+         thrush-and
+         thrush+-and
+         thrush*-and
+         define/thrush-and
+         (rename-out [thrush λ~>]
+                     [thrush+ ~>]
+                     [thrush* ~>*]
+                     [thrush-and λand~>]
+                     [thrush+-and and~>]
+                     [thrush*-and and~>*]))
 
 (define (thrush . fs)
   (apply compose (reverse fs)))
@@ -35,6 +41,22 @@
 (define-syntax-rule (define/thrush id expr ...)
   (define id (thrush expr ...)))
 
-(define λ~> thrush)
-(define ~> thrush+)
-(define ~>* thrush*)
+(define (thrush-and . fs)
+  (define ((apply-and f) v)
+    (and v (f v)))
+  (apply compose1 (map apply-and (reverse fs))))
+
+(module+ test
+  (define (find-odd lst) (findf odd? lst))
+  (define inc-odd (thrush-and find-odd add1))
+  (check-equal? (inc-odd '(2 3 4)) 4)
+  (check-equal? (inc-odd '(2 4 6)) #f))
+
+(define (thrush+-and v . fs)
+  ((apply thrush-and fs) v))
+
+(define ((thrush*-and . vs) . fs)
+  (apply (apply thrush-and fs) vs))
+
+(define-syntax-rule (define/thrush-and id expr ...)
+  (define id (thrush-and expr ...)))


### PR DESCRIPTION
This adds `thrush-and`, bringing point-free up to feature parity with threading so I can finally stop using threading completely. :wink:

Theoretically this is generalizable, but it’s hard to do reasonably with strict evaluation and a non-monadic approach, and it’s unlikely that other related functions would be very useful, so I think providing `thrush-and` directly is a good idea.
